### PR TITLE
Fill Interface and EndPoint fields for all Rx Network buffers

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -543,6 +543,8 @@ static UBaseType_t prvNetworkInterfaceInput( void )
     {
         /*configASSERT( xEthHandle.RxDescList.RxDataLength <= EMAC_DATA_BUFFER_SIZE );*/
         xResult++;
+        pxCurDescriptor->pxInterface = pxMyInterface;
+        pxCurDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxCurDescriptor->pucEthernetBuffer );;
         #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
             if ( pxStartDescriptor == NULL )
             {
@@ -559,7 +561,7 @@ static UBaseType_t prvNetworkInterfaceInput( void )
             {
                 iptraceETHERNET_RX_EVENT_LOST();
                 FreeRTOS_debug_printf( ( "prvNetworkInterfaceInput: xSendEventStructToIPTask failed\n" ) );
-                vReleaseNetworkBufferAndDescriptor( pxStartDescriptor );
+                vReleaseNetworkBufferAndDescriptor( pxCurDescriptor );
             }
         #endif
     }
@@ -568,8 +570,6 @@ static UBaseType_t prvNetworkInterfaceInput( void )
     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
         if( xResult > 0 )
         {
-            pxStartDescriptor->pxInterface = pxMyInterface;
-            pxStartDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxStartDescriptor->pucEthernetBuffer );
             xRxEvent.pvData = ( void * ) pxStartDescriptor;
             if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 100U ) != pdPASS )
             {


### PR DESCRIPTION
When using linked rx messages, only the first network buffer descriptor had `pxInterface` and `pxEndPoint` fields filled. This led to hard faults when dereferencing `pxEndPoint` on:

https://github.com/holden-zenith/FreeRTOS-Plus-TCP/blob/main/source/FreeRTOS_ARP.c#L493