### PR TITLE
Ignore packets whose buffers were dropped

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -547,6 +547,7 @@ static UBaseType_t prvNetworkInterfaceInput( void )
             /* Buffer was dropped, ignore packet */
             continue;
         }
+
         xResult++;
         pxCurDescriptor->pxInterface = pxMyInterface;
         pxCurDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxCurDescriptor->pucEthernetBuffer );;

--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -542,6 +542,11 @@ static UBaseType_t prvNetworkInterfaceInput( void )
     while ( ( HAL_ETH_ReadData( &xEthHandle, ( void ** ) &pxCurDescriptor ) == HAL_OK ) )
     {
         /*configASSERT( xEthHandle.RxDescList.RxDataLength <= EMAC_DATA_BUFFER_SIZE );*/
+        if( pxCurDescriptor == NULL )
+        {
+            /* Buffer was dropped, ignore packet */
+            continue;
+        }
         xResult++;
         pxCurDescriptor->pxInterface = pxMyInterface;
         pxCurDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxCurDescriptor->pucEthernetBuffer );;


### PR DESCRIPTION
I have to admit I don't fully understand how the port works but I did notice that when the buffer is dropped in `HAL_ETH_RxLinkCallback`, the `HAL_ETH_Read` function still returns `HAL_OK` but with a NULL buffer descriptor. This results in a hard fault due to null dereference when receiving a packet that was filtered out. 