### PR TITLE
Support network down event and reinitialization

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -695,16 +695,6 @@ static void prvEMACHandlerTask( void * pvParameters )
         if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != pdFALSE )
         {
             prvEthernetUpdateConfig();
-
-            /*
-             #if ( ipconfigSUPPORT_NETWORK_DOWN_EVENT != 0 )
-                {
-                    if( xGetPhyLinkStatus() == pdFALSE )
-                    {
-                        FreeRTOS_NetworkDown();
-                    }
-                }
-            */
         }
     }
 }

--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -787,6 +787,10 @@ static void prvEthernetUpdateConfig( void )
         /* iptraceNETWORK_INTERFACE_STATUS_CHANGE(); */
         xHalResult = HAL_ETH_Stop_IT( &xEthHandle );
         configASSERT( xHalResult == HAL_OK );
+
+        #if ( ipconfigSUPPORT_NETWORK_DOWN_EVENT != 0 )
+            FreeRTOS_NetworkDown( pxMyInterface );
+        #endif
     }
 }
 

--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -396,7 +396,10 @@ static BaseType_t xSTM32_NetworkInterfaceInitialise( NetworkInterface_t * pxInte
 
         case eMACInitComplete:
             configASSERT( xEthHandle.gState != HAL_ETH_STATE_ERROR );
-            xInitResult = pdPASS;
+            if( xSTM32_GetPhyLinkStatus( pxInterface ) == pdPASS )
+            {
+                xInitResult = pdPASS;
+            }
     }
 
     return xInitResult;

--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -396,6 +396,7 @@ static BaseType_t xSTM32_NetworkInterfaceInitialise( NetworkInterface_t * pxInte
 
         case eMACInitComplete:
             configASSERT( xEthHandle.gState != HAL_ETH_STATE_ERROR );
+
             if( xSTM32_GetPhyLinkStatus( pxInterface ) == pdPASS )
             {
                 xInitResult = pdPASS;


### PR DESCRIPTION
When PHY reports that the link is down, we can use this to inform the network stack that the network is down. The network stack should then periodically call the Initialize function, until it returns pdPASS which informs it that the network is back up. That's why we need to check the link status in this function.