### PR TITLE
prvMACAddressConfig: fix warnings

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -1009,19 +1009,19 @@ static void prvMACAddressConfig( ETH_HandleTypeDef * pxEthHandle, const uint8_t 
     switch(xMACEntry)
     {
         case ETH_MAC_ADDRESS1:
-            HAL_ETH_SetSourceMACAddrMatch( pxEthHandle, ETH_MAC_ADDRESS1, addr );
+            HAL_ETH_SetSourceMACAddrMatch( pxEthHandle, ETH_MAC_ADDRESS1, ( uint8_t* ) addr );
             prvSetMAC_HashFilter( pxEthHandle, addr );
             xMACEntry = ETH_MAC_ADDRESS2;
             break;
 
         case ETH_MAC_ADDRESS2:
-            HAL_ETH_SetSourceMACAddrMatch( pxEthHandle, ETH_MAC_ADDRESS2, addr );
+            HAL_ETH_SetSourceMACAddrMatch( pxEthHandle, ETH_MAC_ADDRESS2, ( uint8_t* )  addr );
             prvSetMAC_HashFilter( pxEthHandle, addr );
             xMACEntry = ETH_MAC_ADDRESS3;
             break;
 
         case ETH_MAC_ADDRESS3:
-            HAL_ETH_SetSourceMACAddrMatch( pxEthHandle, ETH_MAC_ADDRESS3, addr );
+            HAL_ETH_SetSourceMACAddrMatch( pxEthHandle, ETH_MAC_ADDRESS3, ( uint8_t* )  addr );
             prvSetMAC_HashFilter( pxEthHandle, addr );
             xMACEntry = ETH_MAC_ADDRESS0;
             break;


### PR DESCRIPTION
This PR fixes the following GCC warnings:

* passing argument 3 of `HAL_ETH_SetSourceMACAddrMatch` discards `const` qualifier from pointer target type `[-Werror=discarded-qualifiers]`

This makes it possible to compile the driver with `-Wall -Wextra -Werror`.